### PR TITLE
The one missile now disappears when the tip hits the bottom

### DIFF
--- a/spinny_gun.py
+++ b/spinny_gun.py
@@ -319,7 +319,9 @@ def game_loop():
     """The main game loop"""
 
     gun = SpinnyGun(SCREEN, (DISPLAY_WIDTH * 0.5, DISPLAY_HEIGHT * 0.875))
-    missile = Missile(SCREEN)
+    missiles = []
+    missiles.append(Missile(SCREEN))
+
     projectiles = []
 
     while True:
@@ -352,8 +354,10 @@ def game_loop():
         gun.blit()
 
         # If the missile gets to the bottom, replace it with a new missile
-        if missile.y_pos > DISPLAY_HEIGHT:
-            missile = Missile(SCREEN)
+        for missile in missiles:
+            if missile.y_pos > DISPLAY_HEIGHT - missile.image.get_height():
+                missiles.pop(missiles.index(missile))
+                missiles.append(Missile(SCREEN))
 
         # Move and draw missile
         missile.move()


### PR DESCRIPTION
Very small incremental step. We use the bottom of the screen minus the height of the image, so we can substitute different missile images without breaking the behavior.

resolves: #7 